### PR TITLE
Update 20160422_binary_tree.md

### DIFF
--- a/lib/posts/20160422_binary_tree.md
+++ b/lib/posts/20160422_binary_tree.md
@@ -94,10 +94,10 @@ function isSymmetric(root) {
 }
 
 function reverse(t) {
-  var tmp = t.left;
-  t.left = reverse(t.right);
-  t.right = reverse(tmp);
-  return t;
+  return {
+    left: reverse(t.right),
+    right: reverse(t.left)
+  };
 }
 
 function isEqual(t1, t2) {


### PR DESCRIPTION
Doesn't the original code reverse t *destructively*?  Javascript passes objects mutably, so when you've assigned to t.left and t.right, you've altered the original tree.  This doesn't affect the answer you get out of isSymmetric (as long as the two subtrees do not share structure, i.e. you're not actually working with a graph), but would be a very unexpected side-effect for a user of isSymmetric.