### PR TITLE
Fixed type coercion within comparisons and endless recursion error

### DIFF
--- a/lib/posts/20160422_binary_tree.md
+++ b/lib/posts/20160422_binary_tree.md
@@ -95,10 +95,11 @@ function isSymmetric(root) {
 
 function reverse(t) {
   if(t === null) return;
-  var tmp = t.left;
-  t.left = reverse(t.right);
-  t.right = reverse(tmp);
-  return t;
+		return {
+			left: reverse(t.right),
+			right: reverse(t.left)
+  	};
+	}
 }
 
 function isEqual(t1, t2) {

--- a/lib/posts/20160422_binary_tree.md
+++ b/lib/posts/20160422_binary_tree.md
@@ -68,19 +68,17 @@ The first definition leads to the most concise solution:
 
 ```javascript
 function isSymmetric(root) {
-
-	function isSymmetricHelper(t1, t2) {
-		if(t1 === null && t2 === null) {
-			return true;
-		} else if (t1 === null || t2 === null) {
-			return false;
-		} else {
-			return isSymmetricHelper(t1.left, t2.right) &&
-				isSymmetricHelper(t1.right, t2.left);
-		}
-	}
-
-	return isSymmetricHelper(root.left, root.right);
+  function isSymmetricHelper(t1, t2) {
+    if(t1 === null && t2 === null) {
+      return true;
+    } else if (t1 === null || t2 === null) {
+      return false;
+    } else {
+      return isSymmetricHelper(t1.left, t2.right) &&
+        isSymmetricHelper(t1.right, t2.left);
+    }
+  }
+  return isSymmetricHelper(root.left, root.right);
 }
 ```
 
@@ -90,26 +88,24 @@ a binary tree on the whiteboard, and the one that most intern candidates end
 up using to solve the problem in 20 minutes.
 
 ```javascript
-function isSymmetric(root) {
-	function reverse(t) {
-		if(t === null) return; // end recursion.
-		return {
-			left: reverse(t.right),
-			right: reverse(t.left)
-		};
-	}
-
-	function isEqual(t1, t2) {
-		if (t1 == null && t2 == null) {
-			return true;
-		}
-		if (t1 == null || t2 == null) {
-			return false;
-		}
-		return isEqual(t1.left, t2.left) && isEqual(t1.right, t2.right);
-	}	
-
-	return isEqual(reverse(root.left), root.right);
+function isSymmetric2(root) {
+  function reverse(t) {
+    if(t === null) return;
+    return {
+      left: reverse(t.right),
+      right: reverse(t.left)
+    };
+  }
+  function isEqual(t1, t2) {
+    if (t1 == null && t2 == null) {
+      return true;
+    }
+    if (t1 == null || t2 == null) {
+      return false;
+    }
+    return isEqual(t1.left, t2.left) && isEqual(t1.right, t2.right);
+  }	
+  return isEqual(reverse(root.left), root.right);
 }
 ```
 

--- a/lib/posts/20160422_binary_tree.md
+++ b/lib/posts/20160422_binary_tree.md
@@ -95,11 +95,11 @@ function isSymmetric(root) {
 
 function reverse(t) {
   if(t === null) return;
-		return {
-			left: reverse(t.right),
-			right: reverse(t.left)
-  	};
-	}
+    return {
+      left: reverse(t.right),
+      right: reverse(t.left)
+    };
+  }
 }
 
 function isEqual(t1, t2) {

--- a/lib/posts/20160422_binary_tree.md
+++ b/lib/posts/20160422_binary_tree.md
@@ -68,18 +68,19 @@ The first definition leads to the most concise solution:
 
 ```javascript
 function isSymmetric(root) {
-  return isSymmetricHelper(root.left, root.right);
-}
 
-function isSymmetricHelper(t1, t2) {
-  if (t1 === null && t2 === null) {
-    return true;
-  }
-  if (t1 === null || t2 === null) {
-    return false;
-  }
-  return isSymmetricHelper(t1.left, t2.right) &&
-    isSymmetricHelper(t1.right, t2.left);
+	function isSymmetricHelper(t1, t2) {
+		if(t1 === null && t2 === null) {
+			return true;
+		} else if (t1 === null || t2 === null) {
+			return false;
+		} else {
+			return isSymmetricHelper(t1.left, t2.right) &&
+				isSymmetricHelper(t1.right, t2.left);
+		}
+	}
+
+	return isSymmetricHelper(root.left, root.right);
 }
 ```
 
@@ -90,26 +91,25 @@ up using to solve the problem in 20 minutes.
 
 ```javascript
 function isSymmetric(root) {
-  return isEqual(reverse(root.left), root.right);
-}
+	function reverse(t) {
+		if(t === null) return; // end recursion.
+		return {
+			left: reverse(t.right),
+			right: reverse(t.left)
+		};
+	}
 
-function reverse(t) {
-  if(t === null) return;
-    return {
-      left: reverse(t.right),
-      right: reverse(t.left)
-    };
-  }
-}
+	function isEqual(t1, t2) {
+		if (t1 == null && t2 == null) {
+			return true;
+		}
+		if (t1 == null || t2 == null) {
+			return false;
+		}
+		return isEqual(t1.left, t2.left) && isEqual(t1.right, t2.right);
+	}	
 
-function isEqual(t1, t2) {
-  if (t1 === null && t2 === null) {
-    return true;
-  }
-  if (t1 === null || t2 === null) {
-    return false;
-  }
-  return isEqual(t1.left, t2.left) && isEqual(t1.right, t2.right);
+	return isEqual(reverse(root.left), root.right);
 }
 ```
 

--- a/lib/posts/20160422_binary_tree.md
+++ b/lib/posts/20160422_binary_tree.md
@@ -72,10 +72,10 @@ function isSymmetric(root) {
 }
 
 function isSymmetricHelper(t1, t2) {
-  if (t1 == null && t2 == null) {
+  if (t1 === null && t2 === null) {
     return true;
   }
-  if (t1 == null || t2 == null) {
+  if (t1 === null || t2 === null) {
     return false;
   }
   return isSymmetricHelper(t1.left, t2.right) &&
@@ -94,6 +94,7 @@ function isSymmetric(root) {
 }
 
 function reverse(t) {
+  if(t === null) return;
   var tmp = t.left;
   t.left = reverse(t.right);
   t.right = reverse(tmp);
@@ -101,10 +102,10 @@ function reverse(t) {
 }
 
 function isEqual(t1, t2) {
-  if (t1 == null && t2 == null) {
+  if (t1 === null && t2 === null) {
     return true;
   }
-  if (t1 == null || t2 == null) {
+  if (t1 === null || t2 === null) {
     return false;
   }
   return isEqual(t1.left, t2.left) && isEqual(t1.right, t2.right);


### PR DESCRIPTION
Previously, the recursion into reverse(t) never ended and resulted in a error. That has been fixed.

Previously, reverse(t) corrupted the original tree as an unwanted side effect. This could be observed by simply running isSymmetric(root) twice and noticing the generated errors on the second run.  That has been fixed by making an object literal copy of the node within reverse(t). I verified this has been fixed by using nodes with names and then verifying that the original tree remains unchanged and no errors are generated upon consecutive multiple runs.

Removed unwanted type coercion during comparisons by replacing abstract equality "==" comparisons with strict equality "===" comparisons.