### PR TITLE
Recursive solution typo

### DIFF
--- a/lib/posts/20180302_glob_matching.md
+++ b/lib/posts/20180302_glob_matching.md
@@ -45,7 +45,7 @@ function patternMatches(pattern, str) {
 
   if (rightPattern.length === 0) {
     // Nothing left in pattern
-    return pattern.startsWith(str);
+    return str.startsWith(leftPattern);
   }
 
   for (let numChars = 0; numChars < str.length - starIndex; ++numChars) {


### PR DESCRIPTION
Good article. Think there's a mistake in the recursive solution though (see diff). When the `*` is at the end of the current `pattern`, taking the whole pattern and seeing if the str is at the start isn't the right check (abcd is not at the start of ab*). Copying the code and running it against the third example case confirms this.