### PR TITLE
Fixed filterByProperty example

### DIFF
--- a/lib/posts/20190611_arrays.md
+++ b/lib/posts/20190611_arrays.md
@@ -309,7 +309,7 @@ For example, suppose you want a custom array class that supports filtering by pr
 ```javascript
 class MyArray extends Array {
   filterByProperty(name, value) {
-    return this.filter(obj => obj.name === 'value');
+    return this.filter(obj => obj[name] === value);
   }
 }
 


### PR DESCRIPTION
Fixed the filterByProperty example.

I'm not sure why there is a detected change in the "Moving On" paragraph. I didn't change anything in that paragraph.